### PR TITLE
Refactor tab styling into external CSS

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,47 @@
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0;
+  flex-wrap: wrap;
+}
+
+.tab {
+  padding: 6px 10px;
+  border: 1px solid #b2dfdb;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.tab.active {
+  background: #e0f2f1;
+  border-color: #b2dfdb;
+}
+
+.tabpane {
+  display: none;
+  border: 1px solid #b2dfdb;
+  padding: 10px;
+  border-radius: 6px;
+  background: #e0f2f1;
+}
+
+.tabpane.active {
+  display: block;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin: 8px 0;
+  flex-wrap: wrap;
+}
+
+.row input[type="text"] {
+  width: 200px;
+}
+
+.note {
+  color: #666;
+  font-size: 12px;
+}

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Редактор</title></head>
+<head>
+  <meta charset="UTF-8">
+  <title>Редактор</title>
+  <link rel="stylesheet" th:href="@{/style.css}">
+</head>
 <body style="max-width:900px;margin:24px auto;font-family:sans-serif;">
 <a href="/calc"><b>Калькуляторы</b></a>
 <h1 th:text="${m.id}==null ? 'Новый препарат' : 'Редактирование'"></h1>
@@ -22,16 +26,6 @@
   <!-- Почки (вкладки с категориями КК) -->
   <h2 style="margin-top:16px;">Почки</h2>
 
-  <style>
-.tabs { display:flex; gap:8px; margin:8px 0; flex-wrap:wrap; }
-.tab { padding:6px 10px; border:1px solid #888; border-radius:6px; cursor:pointer; }
-.tab.active { background:#eef; border-color:#55f; }
-.tabpane { display:none; border:1px solid #ddd; padding:10px; border-radius:6px; }
-.tabpane.active { display:block; }
-.row { display:flex; gap:12px; align-items:center; margin:8px 0; flex-wrap:wrap; }
-.row input[type="text"] { width:200px; }
-.note { color:#666; font-size: 12px; }
-</style>
 
   <div class="tabs" id="renalTabs">
     <div class="tab active" data-pane="gte60">КК ≥ 60</div>


### PR DESCRIPTION
## Summary
- Move renal tab styles from inline block to new static/style.css
- Apply soft teal border/background colors and reuse classes `.tab`, `.tab.active`, `.tabpane`
- Link form template to external stylesheet

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf0a05d9083319299e0db97f4f0af