### PR TITLE
Add reusable navbar fragment with styling

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,20 @@
+.navbar {
+  background-color: #e6f7ff;
+  border-bottom: 1px solid #2e8b57;
+  padding: 10px 16px;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+.navbar-brand {
+  font-weight: bold;
+  color: #2e8b57;
+}
+.navbar a {
+  color: #2e8b57;
+  text-decoration: none;
+}
+.navbar-status {
+  margin-left: auto;
+  opacity: 0.7;
+}

--- a/src/main/resources/templates/calc_bmi.html
+++ b/src/main/resources/templates/calc_bmi.html
@@ -1,14 +1,12 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Калькуляторы — ИМТ</title></head>
+<head>
+<meta charset="UTF-8">
+<title>Калькуляторы — ИМТ</title>
+<link rel="stylesheet" th:href="@{/style.css}">
+</head>
 <body style="max-width:1000px;margin:24px auto;font-family:sans-serif;">
-<!-- NAV -->
-<div style="background:#f5f5f5;border-bottom:1px solid #ddd;padding:10px 16px;display:flex;gap:14px;align-items:center;">
-  <b>MedApp</b>
-  <a href="/calc"><b>Калькуляторы</b></a>
-  <a href="/">Препараты</a>
-  <span style="margin-left:auto;opacity:.7;">Локально · офлайн</span>
-</div>
+<div th:replace="fragments/nav :: nav"></div>
 
 <h1 style="margin-top:16px;">Калькуляторы</h1>
 <div style="display:flex;gap:16px;">

--- a/src/main/resources/templates/calc_renal.html
+++ b/src/main/resources/templates/calc_renal.html
@@ -1,14 +1,12 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Калькуляторы — СКФ и КК</title></head>
+<head>
+<meta charset="UTF-8">
+<title>Калькуляторы — СКФ и КК</title>
+<link rel="stylesheet" th:href="@{/style.css}">
+</head>
 <body style="max-width:1000px;margin:24px auto;font-family:sans-serif;">
-<!-- NAV -->
-<div style="background:#f5f5f5;border-bottom:1px solid #ddd;padding:10px 16px;display:flex;gap:14px;align-items:center;">
-  <b>MedApp</b>
-  <a href="/calc"><b>Калькуляторы</b></a>
-  <a href="/">Препараты</a>
-  <span style="margin-left:auto;opacity:.7;">Локально · офлайн</span>
-</div>
+<div th:replace="fragments/nav :: nav"></div>
 
 <h1 style="margin-top:16px;">СКФ (CKD-EPI 2021) + КК (Cockcroft–Gault)</h1>
 

--- a/src/main/resources/templates/details.html
+++ b/src/main/resources/templates/details.html
@@ -1,8 +1,12 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title th:text="${m.name}">Детали</title></head>
+<head>
+<meta charset="UTF-8">
+<title th:text="${m.name}">Детали</title>
+<link rel="stylesheet" th:href="@{/style.css}">
+</head>
 <body style="max-width:900px;margin:24px auto;font-family:sans-serif;">
-<a href="/calc"><b>Калькуляторы</b></a>
+<div th:replace="fragments/nav :: nav"></div>
 <a href="/">&larr; Назад</a>
 <h1 th:text="${m.name}">Название</h1>
 <p><b>ID:</b> <span th:text="${m.id}"></span></p>

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -1,8 +1,12 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Редактор</title></head>
+<head>
+<meta charset="UTF-8">
+<title>Редактор</title>
+<link rel="stylesheet" th:href="@{/style.css}">
+</head>
 <body style="max-width:900px;margin:24px auto;font-family:sans-serif;">
-<a href="/calc"><b>Калькуляторы</b></a>
+<div th:replace="fragments/nav :: nav"></div>
 <h1 th:text="${m.id}==null ? 'Новый препарат' : 'Редактирование'"></h1>
 
 <form th:action="${m.id}==null ? @{/meds} : @{'/meds/' + ${m.id}}" method="post" >

--- a/src/main/resources/templates/fragments/nav.html
+++ b/src/main/resources/templates/fragments/nav.html
@@ -1,0 +1,6 @@
+<nav th:fragment="nav" class="navbar">
+  <span class="navbar-brand">MedApp</span>
+  <a href="/calc"><b>Калькуляторы</b></a>
+  <a href="/">Препараты</a>
+  <span class="navbar-status">Локально · офлайн</span>
+</nav>

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -1,9 +1,13 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
-<head><meta charset="UTF-8"><title>Препараты</title></head>
+<head>
+<meta charset="UTF-8">
+<title>Препараты</title>
+<link rel="stylesheet" th:href="@{/style.css}">
+</head>
 <body style="max-width:900px;margin:24px auto;font-family:sans-serif;">
+<div th:replace="fragments/nav :: nav"></div>
 <h1>Препараты</h1>
-<a href="/calc"><b>Калькуляторы</b></a>
 <form method="get" action="/" style="margin:12px 0;">
     <input name="q" th:value="${q}" placeholder="поиск по названию" style="width:260px;">
     <button type="submit">Искать</button>


### PR DESCRIPTION
## Summary
- create `nav.html` fragment and apply across templates via `th:replace`
- add `style.css` with light-blue navbar and green accents
- link stylesheet in templates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf09cc6148331afca1bc59a81da72